### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ takePhoto.Clicked += async (sender, args) =>
     
     if (!CrossMedia.Current.IsCameraAvailable || !CrossMedia.Current.IsTakePhotoSupported)
     {
-        DisplayAlert("No Camera", ":( No camera available.", "OK");
+        await DisplayAlert("No Camera", ":( No camera available.", "OK");
         return;
     }
 
@@ -247,7 +247,10 @@ var file = await CrossMedia.Current.TakePhotoAsync(new StoreCameraMediaOptions
 ###  Important Permission Information
 Please read these as they must be implemented for all platforms.
 
-#### Android 
+#### Android
+
+Before changing the manifest, please make sure that you are working with the correct manifest file. It is possible to have two manifest files, one for Release build (AndroidManifest.xml), and another for Debug build (AndroidManifest.debug.xml) and in some projects this option is turned on in xxxxAndroid.csproj file.
+
 The `WRITE_EXTERNAL_STORAGE` & `READ_EXTERNAL_STORAGE` permissions are required, but the library will automatically add this for you. Additionally, if your users are running Marshmallow the Plugin will automatically prompt them for runtime permissions. You must add `Xamarin.Essentials.Platform.OnRequestPermissionsResult` code into your Main or Base Activities:
 
 Add to Activity:


### PR DESCRIPTION
+ Fix typo in the code
+ Added important note regarding android manifests

Please take a moment to fill out the following:

Fixes # Fixed typo in the code, added await to the async call to AlertDisplay()
Updates # Updated README with notice about android manifest files.

Changes Proposed in this pull request:
Added important note about android manifest to the android section of README. In some Xamarin solutions you may have 2 android manifests, one for Debug build, another for Release. And upon changing the incorrect manifest you get errors, that take significant time to fix. I spent several days to fix issue related to the camera (unable to find file provider exception). Hope it helps other devs and saves their nerves :)
